### PR TITLE
fix(search): fix multi search result skip

### DIFF
--- a/pkg/bluge/search/search.go
+++ b/pkg/bluge/search/search.go
@@ -154,7 +154,8 @@ type DocumentList struct {
 
 func (d *DocumentList) Done() {
 	// do skip
-	for i := int64(0); i < d.from && i < int64(d.Len()); i++ {
+	alldocLen := int64(d.Len())
+	for i := int64(0); i < d.from && i < alldocLen; i++ {
 		heap.Pop(d)
 	}
 	// log size


### PR DESCRIPTION
当pop的时候，d.Len()会不断减少，所以无法满足跳过一半以上的需求，也就是当from超过一半之后，会一直返回重复的数据