### PR TITLE
perf: avoid allocations with `(*regexp.Regexp).MatchString`

### DIFF
--- a/pkg/core/newindex.go
+++ b/pkg/core/newindex.go
@@ -40,7 +40,7 @@ func CheckIndexName(name string) error {
 	if strings.HasPrefix(name, "_") {
 		return fmt.Errorf("index name cannot start with _")
 	}
-	if !indexNameRe.Match([]byte(name)) {
+	if !indexNameRe.MatchString(name) {
 		return fmt.Errorf("index name [%s] is invalid, just accept [a-zA-Z0-9_.-]", name)
 	}
 	return nil


### PR DESCRIPTION
We should use `(*regexp.Regexp).MatchString` instead of `(*regexp.Regexp).Match([]byte(...))` when matching string to avoid unnecessary `[]byte` conversions and reduce allocations. A one-line change for free performance improvement.

Example benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := indexNameRe.Match([]byte("TestCheckIndexName.index_1")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := indexNameRe.MatchString("TestCheckIndexName.index_1"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: github.com/zincsearch/zincsearch/pkg/core
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 1530795	       776.2 ns/op	      32 B/op	       1 allocs/op
BenchmarkMatchString-16    	 2233713	       591.4 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/zincsearch/zincsearch/pkg/core	3.799s
```