### PR TITLE
fix ngram tokenizer

### DIFF
--- a/pkg/bluge/analysis/tokenizer/edge_ngram.go
+++ b/pkg/bluge/analysis/tokenizer/edge_ngram.go
@@ -40,6 +40,7 @@ func (t *EdgeNgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
 	n := utf8.RuneCount(input)
 	runes := bytes.Runes(input)
 	start := 0
+	var byteStart = start
 	rv := make(analysis.TokenStream, 0, n)
 	for i := 1; i <= n; i++ {
 		if i-start >= t.minLength {
@@ -53,14 +54,16 @@ func (t *EdgeNgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
 				}
 			}
 			if valid {
+				var term = analysis.BuildTermFromRunes(runes[start:i])
 				rv = append(rv, &analysis.Token{
 					Term:         analysis.BuildTermFromRunes(runes[start:i]),
 					PositionIncr: 1,
-					Start:        start,
-					End:          i,
+					Start:        byteStart,
+					End:          byteStart + len(term),
 					Type:         analysis.AlphaNumeric,
 				})
 			} else {
+				byteStart = byteStart + utf8.RuneLen(runes[start])
 				start = i
 				continue
 			}

--- a/pkg/bluge/analysis/tokenizer/edge_ngram.go
+++ b/pkg/bluge/analysis/tokenizer/edge_ngram.go
@@ -56,7 +56,7 @@ func (t *EdgeNgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
 			if valid {
 				var term = analysis.BuildTermFromRunes(runes[start:i])
 				rv = append(rv, &analysis.Token{
-					Term:         analysis.BuildTermFromRunes(runes[start:i]),
+					Term:         term,
 					PositionIncr: 1,
 					Start:        byteStart,
 					End:          byteStart + len(term),

--- a/pkg/bluge/analysis/tokenizer/edge_ngram.go
+++ b/pkg/bluge/analysis/tokenizer/edge_ngram.go
@@ -16,6 +16,9 @@
 package tokenizer
 
 import (
+	"bytes"
+	"unicode/utf8"
+
 	"github.com/blugelabs/bluge/analysis"
 )
 
@@ -34,14 +37,15 @@ func NewEdgeNgramTokenizer(minLength, maxLength int, tokenChars []string) *EdgeN
 }
 
 func (t *EdgeNgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
-	n := len(input)
+	n := utf8.RuneCount(input)
+	runes := bytes.Runes(input)
 	start := 0
 	rv := make(analysis.TokenStream, 0, n)
 	for i := 1; i <= n; i++ {
 		if i-start >= t.minLength {
 			valid := true
 			if len(t.tokenChars) > 0 {
-				for _, c := range string(input[start:i]) {
+				for _, c := range string(runes[start:i]) {
 					if !t.isChar(c) {
 						valid = false
 						break
@@ -50,7 +54,7 @@ func (t *EdgeNgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
 			}
 			if valid {
 				rv = append(rv, &analysis.Token{
-					Term:         input[start:i],
+					Term:         analysis.BuildTermFromRunes(runes[start:i]),
 					PositionIncr: 1,
 					Start:        start,
 					End:          i,

--- a/pkg/bluge/analysis/tokenizer/ngram.go
+++ b/pkg/bluge/analysis/tokenizer/ngram.go
@@ -41,6 +41,7 @@ func (t *NgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
 	runes := bytes.Runes(input)
 	start := 0
 	rv := make(analysis.TokenStream, 0, n)
+	var byteStart = start
 	for i := 1; i <= n; i++ {
 		if i-start >= t.minLength {
 			valid := true
@@ -53,17 +54,19 @@ func (t *NgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
 				}
 			}
 			if valid {
+				var term = analysis.BuildTermFromRunes(runes[start:i])
 				rv = append(rv, &analysis.Token{
-					Term:         analysis.BuildTermFromRunes(runes[start:i]),
+					Term:         term,
 					PositionIncr: 1,
-					Start:        start,
-					End:          i,
+					Start:        byteStart,
+					End:          byteStart + len(term),
 					Type:         analysis.AlphaNumeric,
 				})
 			}
 		}
 
 		if i-start == t.maxLength {
+			byteStart = byteStart + utf8.RuneLen(runes[start])
 			start = start + 1
 			i = start
 		}

--- a/pkg/bluge/analysis/tokenizer/ngram.go
+++ b/pkg/bluge/analysis/tokenizer/ngram.go
@@ -16,6 +16,9 @@
 package tokenizer
 
 import (
+	"bytes"
+	"unicode/utf8"
+
 	"github.com/blugelabs/bluge/analysis"
 )
 
@@ -34,14 +37,15 @@ func NewNgramTokenizer(minLength, maxLength int, tokenChars []string) *NgramToke
 }
 
 func (t *NgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
-	n := len(input)
+	n := utf8.RuneCount(input)
+	runes := bytes.Runes(input)
 	start := 0
 	rv := make(analysis.TokenStream, 0, n)
 	for i := 1; i <= n; i++ {
 		if i-start >= t.minLength {
 			valid := true
 			if len(t.tokenChars) > 0 {
-				for _, c := range string(input[start:i]) {
+				for _, c := range string(runes[start:i]) {
 					if !t.isChar(c) {
 						valid = false
 						break
@@ -50,7 +54,7 @@ func (t *NgramTokenizer) Tokenize(input []byte) analysis.TokenStream {
 			}
 			if valid {
 				rv = append(rv, &analysis.Token{
-					Term:         input[start:i],
+					Term:         analysis.BuildTermFromRunes(runes[start:i]),
 					PositionIncr: 1,
 					Start:        start,
 					End:          i,


### PR DESCRIPTION
I ceate a index with ngram tokenizer, and I try to use it to index some Chinese text, like `java入门到精通`. The analazyer API returns some invliad garbled characters.

I found the nagram tokenzier splits the input bytes directly. For Chiensee content, this is not an appropriate approach, so I try to fix this.

After that, the analazyer API returns the correct tokenization result.