### PR TITLE
full support for minimum_should_match

### DIFF
--- a/pkg/meta/query_dsl.go
+++ b/pkg/meta/query_dsl.go
@@ -102,7 +102,7 @@ type BoolQuery struct {
 	Must               interface{} `json:"must,omitempty"`                 // query, [query1, query2]
 	MustNot            interface{} `json:"must_not,omitempty"`             // query, [query1, query2]
 	Filter             interface{} `json:"filter,omitempty"`               // query, [query1, query2]
-	MinimumShouldMatch float64     `json:"minimum_should_match,omitempty"` // only for should
+	MinimumShouldMatch interface{} `json:"minimum_should_match,omitempty"` // only for should
 }
 
 type BoolQueryForSDK struct {
@@ -151,13 +151,13 @@ type MatchPhrasePrefixQuery struct {
 }
 
 type MultiMatchQuery struct {
-	Query              string   `json:"query,omitempty"`
-	Analyzer           string   `json:"analyzer,omitempty"`
-	Fields             []string `json:"fields,omitempty"`
-	Boost              float64  `json:"boost,omitempty"`
-	Type               string   `json:"type,omitempty"`     // best_fields(default), most_fields, cross_fields, phrase, phrase_prefix, bool_prefix
-	Operator           string   `json:"operator,omitempty"` // or(default), and
-	MinimumShouldMatch float64  `json:"minimum_should_match,omitempty"`
+	Query              string      `json:"query,omitempty"`
+	Analyzer           string      `json:"analyzer,omitempty"`
+	Fields             []string    `json:"fields,omitempty"`
+	Boost              float64     `json:"boost,omitempty"`
+	Type               string      `json:"type,omitempty"`     // best_fields(default), most_fields, cross_fields, phrase, phrase_prefix, bool_prefix
+	Operator           string      `json:"operator,omitempty"` // or(default), and
+	MinimumShouldMatch interface{} `json:"minimum_should_match,omitempty"`
 }
 
 type CombinedFieldsQuery struct {

--- a/pkg/zutils/min_should.go
+++ b/pkg/zutils/min_should.go
@@ -1,0 +1,152 @@
+package zutils
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type combination struct {
+	condition int
+	count     int
+}
+
+var regex = regexp.MustCompile(`(\d+)<([-+]?\d+%?)`)
+
+// CalculateMin
+// calculate the MinimumShouldMatch value with given expr and sub query count.
+func CalculateMin(subCount int, v interface{}) (res int, err error) {
+	if subCount == 0 {
+		return 1, nil
+	}
+	defer func() {
+		if err != nil {
+			return
+		}
+		if res <= 1 {
+			res = 1
+			return
+		}
+		if res >= subCount {
+			res = subCount
+			return
+		}
+	}()
+	switch x := v.(type) {
+	case int64, int, float64:
+		m := 0
+		switch val := v.(type) {
+		case int:
+			m = val
+		case int64:
+			m = int(val)
+		case float64:
+			m = int(math.Floor(val))
+		}
+		if m < 0 {
+			m = subCount + m
+		}
+		return m, nil
+	case []string:
+		conditions := make([]combination, len(x))
+		for i, str := range x {
+			match := regex.FindStringSubmatch(str)
+			if match != nil {
+				leftPart := match[1]
+				rightPart := match[2]
+				condition, err := strconv.ParseInt(leftPart, 10, 64)
+				if err != nil {
+					return 0, fmt.Errorf("cannot parse the condition value: %w", err)
+				}
+				count, err := getPartValue(subCount, rightPart)
+				if err != nil {
+					return 0, fmt.Errorf("cannot parse the clauses count: %w", err)
+				}
+				conditions[i] = combination{
+					condition: int(condition),
+					count:     count,
+				}
+			} else {
+				return 0, fmt.Errorf("invalid MinimumShould value: %s", x)
+			}
+		}
+
+		sort.Slice(conditions, func(i, j int) bool {
+			return conditions[i].condition < conditions[j].condition
+		})
+
+		for i, condition := range conditions {
+			// only match first
+			if subCount <= condition.condition {
+				return subCount, nil
+			}
+			// we are the last one, matched
+			if i == len(conditions)-1 {
+				return condition.count, nil
+			}
+			// less than next, we matched
+			if subCount <= conditions[i+1].condition {
+				return condition.count, nil
+			}
+		}
+		return 0, fmt.Errorf("invalid MinimumShould value: %v", x)
+	case string:
+		combinations := strings.Split(x, " ")
+		if len(combinations) > 1 {
+			return CalculateMin(subCount, combinations)
+		}
+		// simple expr
+		if res, err := getPartValue(subCount, x); err == nil {
+			return res, nil
+		}
+
+		// complex, we use regex
+		match := regex.FindStringSubmatch(x)
+		if match != nil {
+			leftPart := match[1]
+			rightPart := match[2]
+			condition, err := strconv.ParseInt(leftPart, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("cannot parse the condition value: %w", err)
+			}
+			count, err := getPartValue(subCount, rightPart)
+			if err != nil {
+				return 0, fmt.Errorf("cannot parse the clauses count: %w", err)
+			}
+			if subCount <= int(condition) {
+				return subCount, nil
+			}
+			return count, nil
+		} else {
+			return 0, fmt.Errorf("invalid MinimumShould value: %s", x)
+		}
+	default:
+		return 0, fmt.Errorf("invalid MinimumShouldMatch value")
+	}
+}
+
+func getPartValue(termCount int, part string) (int, error) {
+	if strings.Contains(part, "%") {
+		proportion, err := strconv.ParseInt(part[0:len(part)-1], 10, 64)
+		if err != nil {
+			return 0, fmt.Errorf("cannot parse a percent value: %w", err)
+		}
+		if proportion < 0 {
+			count := float64(termCount) * float64(-proportion) / 100
+			return termCount - int(count), nil
+		}
+		count := float64(termCount) * float64(proportion) / 100
+		return int(count), nil
+	}
+	count, err := strconv.ParseInt(part, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse a int value: %w", err)
+	}
+	if count < 0 {
+		return termCount + int(count), nil
+	}
+	return int(count), nil
+}

--- a/pkg/zutils/min_should_test.go
+++ b/pkg/zutils/min_should_test.go
@@ -1,0 +1,53 @@
+package zutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalculateMin(t *testing.T) {
+	cases := []struct {
+		subCount int
+		value    interface{}
+		want     int
+	}{
+		// Simple Integer
+		{subCount: 5, value: 3, want: 3},
+		{subCount: 10, value: "2", want: 2},
+		{subCount: 8, value: int64(7), want: 7},
+		{subCount: 9, value: 3.0, want: 3},
+		{subCount: 5, value: 5.7, want: 5},
+
+		{subCount: 5, value: -10, want: 1},
+		{subCount: 3, value: 5, want: 3},
+
+		// Negative Integer
+		{subCount: 10, value: -2, want: 8},
+		{subCount: 8, value: "-5", want: 3},
+		{subCount: 15, value: -3.0, want: 12},
+		{subCount: 9, value: -3.5, want: 5},
+
+		// percent
+		{subCount: 10, value: "80%", want: 8},
+		{subCount: 10, value: "-20%", want: 8},
+		{subCount: 5, value: "75%", want: 3},
+		{subCount: 5, value: "-25%", want: 4},
+
+		// combination
+		{subCount: 4, value: "5<90%", want: 4},
+		{subCount: 5, value: "5<90%", want: 5},
+		{subCount: 7, value: "5<3", want: 3},
+		{subCount: 5, value: "2<-25%", want: 4},
+
+		// multi combinations
+		{subCount: 2, value: "2<-25% 9<-3", want: 2},
+		{subCount: 5, value: "4<-25% 9<-3", want: 4},
+		{subCount: 10, value: "4<-40% 9<-3", want: 7},
+	}
+	for _, c := range cases {
+		v, err := CalculateMin(c.subCount, c.value)
+		assert.Nil(t, err)
+		assert.Equal(t, c.want, v)
+	}
+}


### PR DESCRIPTION
ElasticSearch support a very flexible way to use [minimum_should_match](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html).

Bluge supports the minimum_should_match but must be a integer.、

A `match query` is split by the tokenization into multiple `term queries`, and these subqueries are where minimum_should_match should work. We can calculate the correct min value from the tokenization result and minimum_should_match expression, and then pass it to bluge.

